### PR TITLE
Update Kademlia to use TargetID in RPC calls

### DIFF
--- a/internal/kademlia/network_test.go
+++ b/internal/kademlia/network_test.go
@@ -31,7 +31,7 @@ func TestUpdateRoutingTable(t *testing.T) {
 	c := NewContact(NewNodeID("1111111400000000000000000000000000000000"), "localhost:8002")
 
 	target := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
-	rpc, _ := NewRPC(Ping, target.ID.String(), payload)
+	rpc, _ := NewRPC(Ping, target.ID.String(), "", payload)
 
 	node := Node{}
 	node.RT = NewRoutingTable(c)
@@ -50,7 +50,7 @@ func TestHandleIncomingPing(t *testing.T) {
 	payload := Payload{&pingMsg, nil, nil}
 	target := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
 
-	rpc, _ := NewRPC(Ping, target.ID.String(), payload)
+	rpc, _ := NewRPC(Ping, target.ID.String(), "", payload)
 	r, err := network.handleIncomingPingRPC(rpc)
 	assert.Equal(t, r, rpc)
 	assert.Nil(t, err)
@@ -58,22 +58,42 @@ func TestHandleIncomingPing(t *testing.T) {
 	r, err = network.handleIncomingPingRPC(nil)
 	assert.Nil(t, r)
 	assert.Equal(t, errors.New(errNilRPC), err)
+
 }
 
 func TestHandleIncomingFindNode(t *testing.T) {
 	node := Node{}
+	c := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
+	node.RT = NewRoutingTable(c)
 	network := NewNetwork(&node)
 	payload := Payload{nil, nil, []Contact{}}
-	target := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
 
-	rpc, err := NewRPC(FindNode, target.ID.String(), payload)
+	rpc, err := NewRPC(FindNode, "00000000000000000000000000000000FFFFFFFF", "1111111100000000000000000000000000000000", payload)
 
-	r, err := network.handleIncomingFindNodeRPC(rpc)
-	assert.Equal(t, r, rpc)
+	_, err = network.handleIncomingFindNodeRPC(rpc)
 	assert.Equal(t, errors.New(errNoContact), err)
 
 	_, err = network.handleIncomingFindNodeRPC(nil)
 	assert.Equal(t, errors.New(errNilRPC), err)
+
+	rpc.TargetID = nil
+	_, err = network.handleIncomingFindNodeRPC(rpc)
+	assert.Equal(t, errors.New(errNoTargetID), err)
+}
+
+func TestHandleIncomingFindNodeWithContacts(t *testing.T) {
+	node := Node{}
+	c := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
+	node.RT = NewRoutingTable(c)
+	network := NewNetwork(&node)
+	payload := Payload{nil, nil, []Contact{}}
+
+	newC := NewContact(NewNodeID("1111111100000000000000000000000000000000"), "10.0.8.2:8080")
+	node.RT.AddContact(newC)
+	rpc, _ := NewRPC(FindNode, "00000000000000000000000000000000FFFFFFFF", "1111111100000000000000000000000000000000", payload)
+	rpc, err := network.handleIncomingFindNodeRPC(rpc)
+	assert.Nil(t, err)
+	assert.Equal(t, rpc.Payload.Contacts[0].ID, newC.ID)
 }
 
 func TestHandleIncomingRPCS(t *testing.T) {
@@ -84,27 +104,34 @@ func TestHandleIncomingRPCS(t *testing.T) {
 	pingMsg := pingMsg
 	payload := Payload{nil, &pingMsg, nil}
 
-	orgRPC, _ := NewRPC(Ping, "1111111100000000000000000000000000000000", payload)
+	orgRPC, _ := NewRPC(Ping, "1111111100000000000000000000000000000000", "00000000000000000000000000000000FFFFFFFF", payload)
 	rpc, err := network.handleIncomingRPCS(orgRPC, "10.0.8.3:8080")
 
 	assert.Equal(t, orgRPC, rpc)
 	assert.Equal(t, OK, *rpc.Type)
 	assert.Nil(t, err)
 
-	storeRPC, _ := NewRPC(Store, "1111111100000000000000000000000000000000", Payload{nil, nil, []Contact{}})
+	storeRPC, _ := NewRPC(Store, "1111111100000000000000000000000000000000", "00000000000000000000000000000000FFFFFFFF", Payload{nil, nil, []Contact{}})
 	_, err = network.handleIncomingRPCS(storeRPC, "10.0.8.3:8080")
 	assert.Error(t, err)
 
-	nodeRPC, _ := NewRPC(FindNode, "1111111100000000000000000000000000000000", Payload{nil, nil, []Contact{}})
-	_, err = network.handleIncomingRPCS(nodeRPC, "10.0.8.3:8080")
-	assert.Error(t, err)
-
-	valueRPC, _ := NewRPC(FindValue, "1111111100000000000000000000000000000000", Payload{nil, nil, []Contact{}})
+	valueRPC, _ := NewRPC(FindValue, "1111111100000000000000000000000000000000", "00000000000000000000000000000000FFFFFFFF", Payload{nil, nil, []Contact{}})
 	_, err = network.handleIncomingRPCS(valueRPC, "10.0.8.3:8080")
 	assert.Error(t, err)
 
-	wrongRPC, _ := NewRPC(OK, "1111111100000000000000000000000000000000", Payload{nil, nil, []Contact{}})
+	wrongRPC, _ := NewRPC(OK, "1111111100000000000000000000000000000000", "00000000000000000000000000000000FFFFFFFF", Payload{nil, nil, []Contact{}})
 	_, err = network.handleIncomingRPCS(wrongRPC, "10.0.8.3:8080")
+	assert.Error(t, err)
+}
+
+func TestHandleIncomingRPCsFindValue(t *testing.T) {
+	node := Node{}
+	c := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
+	node.RT = NewRoutingTable(c)
+	network := NewNetwork(&node)
+
+	nodeRPC, _ := NewRPC(FindNode, "1111111100000000000000000000000000000000", "00000100000000000000000000000000FFFFFFFF", Payload{nil, nil, []Contact{}})
+	_, err := network.handleIncomingRPCS(nodeRPC, "10.0.8.3:8080")
 	assert.Error(t, err)
 }
 
@@ -120,7 +147,7 @@ func TestPingError(t *testing.T) {
 
 func TestFindNodeError(t *testing.T) {
 	network := Network{}
-	_, err := network.SendFindContactMessage(nil, nil)
+	_, err := network.SendFindContactMessage(nil, nil, nil)
 	assert.Error(t, err)
 }
 
@@ -140,6 +167,23 @@ func TestStoreError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestHandleIncomingStore(t *testing.T) {
+	node := Node{nil, Network{}, make(map[string]string)}
+	c := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
+	node.RT = NewRoutingTable(c)
+	network := NewNetwork(&node)
+
+	key := "hello"
+	value := "good bye"
+	payload := Payload{&key, &value, []Contact{}}
+
+	rpc, _ := NewRPC(Store, "10000000000000000000000000000000FFFFFFFF", "00000000000000000000000000000000FFFFFFFF", payload)
+	rpc, err := network.handleIncomingStoreRPC(rpc)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, rpc)
+}
+
 func TestHandleIncomingStoreError(t *testing.T) {
 	storeType := Store
 
@@ -147,17 +191,17 @@ func TestHandleIncomingStoreError(t *testing.T) {
 	_, err := network.handleIncomingStoreRPC(nil)
 	assert.Error(t, err)
 
-	rpc := RPC{&storeType, nil, nil, nil}
+	rpc := RPC{&storeType, nil, nil, nil, nil}
 	_, err = network.handleIncomingStoreRPC(&rpc)
 	assert.Error(t, err)
 
 	payload := Payload{nil, nil, []Contact{}}
-	rpc = RPC{&storeType, &payload, nil, nil}
+	rpc = RPC{&storeType, &payload, nil, nil, nil}
 	_, err = network.handleIncomingStoreRPC(&rpc)
 	assert.Error(t, err)
 }
 
-func TestHandleIncomingFindValue(t *testing.T) {
+func TestHandleIncomingFindValueWithoutKey(t *testing.T) {
 	findValue := FindValue
 	network := Network{}
 
@@ -165,14 +209,44 @@ func TestHandleIncomingFindValue(t *testing.T) {
 	assert.Equal(t, errors.New(errNilRPC), err)
 
 	payload := Payload{nil, nil, []Contact{}}
-	rpc := RPC{&findValue, &payload, nil, nil}
+	rpc := RPC{&findValue, &payload, nil, nil, nil}
 	_, err = network.handleIncomingFindValueRPC(&rpc)
-	assert.Equal(t, errors.New(errBadKeyValue), err)
+	assert.Equal(t, errors.New(errNoTargetID), err)
+
+}
+
+func TestHandleIncomingFindValueNoValueInStore(t *testing.T) {
+	node := Node{}
+	c := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
+	node.RT = NewRoutingTable(c)
+	network := NewNetwork(&node)
+
+	key := "1111111100000000000000000000000000000000"
+	payload := Payload{&key, nil, []Contact{}}
+	rpc, _ := NewRPC(FindValue, "00000000000000000000000000000000FFFFFFFF", "1111111100000000000000000000000000000000", payload)
+	rpc, err := network.handleIncomingFindValueRPC(rpc)
+	assert.Equal(t, errors.New(errNoContact), err)
+}
+
+func TestHandleIncomingFindValueExist(t *testing.T) {
+	node := Node{nil, Network{}, make(map[string]string)}
+	c := NewContact(NewNodeID("00000000000000000000000000000000FFFFFFFF"), "10.0.8.1:8080")
+	node.RT = NewRoutingTable(c)
+	network := NewNetwork(&node)
+
+	key := "1111111100000000000000000000000000000000"
+	value := "hello"
+	payload := Payload{&key, nil, []Contact{}}
+	node.insertLocalStore(key, value)
+	rpc, _ := NewRPC(FindValue, "00000000000000000000000000000000FFFFFFFF", "1111111100000000000000000000000000000000", payload)
+	rpc, err := network.handleIncomingFindValueRPC(rpc)
+	assert.Nil(t, err)
+	assert.Equal(t, value, *rpc.Payload.Value)
 }
 
 func TestListenErrors(t *testing.T) {
 	network := Network{}
-	// Port 1 is reserved and can never be used
+	// Port 1 is reserved and can never be used so should always throw error
 	err := network.Listen("127.0.0.1", "1")
 	assert.Error(t, err)
 }
@@ -185,6 +259,6 @@ func TestSendRPCNoNetwork(t *testing.T) {
 	c := NewContact(nodeID, "10.0.8.1:8080")
 
 	payload := Payload{nil, nil, []Contact{}}
-	_, err := network.sendRPC(&c, Ping, nodeID, payload)
+	_, err := network.sendRPC(&c, Ping, nodeID, nodeID, payload)
 	assert.Error(t, err)
 }

--- a/internal/kademlia/node.go
+++ b/internal/kademlia/node.go
@@ -71,7 +71,7 @@ func (kademlia *Node) NodeLookup(targetID *NodeID) []Contact {
 			if probedNodes.Contains(shortList.contacts[i]) {
 				continue
 			} else {
-				rpc, err := kademlia.network.SendFindContactMessage(&shortList.contacts[i], &kademlia.RT.me)
+				rpc, err := kademlia.network.SendFindContactMessage(&shortList.contacts[i], &kademlia.RT.me, targetID)
 
 				// if a node responds with an error remove that node from the shortlist and from the bucket
 				if err != nil {
@@ -257,7 +257,7 @@ func (kademlia *Node) updateBucket(bucket bucket, contact Contact) {
 // if found else nil.
 func (kademlia *Node) searchLocalStore(key string) *string {
 	value, exists := kademlia.content[key]
-	if exists {
+	if !exists {
 		return nil
 	}
 	return &value

--- a/internal/kademlia/rpc.go
+++ b/internal/kademlia/rpc.go
@@ -27,11 +27,13 @@ var rpcTypes = []RPCType{Ping, Store, FindValue, FindNode, OK}
 
 // RPC contains the `Type` of the RPC, the `Payload` (data). A quasi random `ID` for
 // that RPC. `SenderID` which is the NodeID of the node who originally sent it.
+// `TargetID` is the NodeID we're looking for.
 type RPC struct {
 	Type     *RPCType `json:"type"`
 	Payload  *Payload `json:"payload"`
 	ID       *string  `json:"id"`
 	SenderID *string  `json:"senderID"`
+	TargetID *string  `json:"targetID"`
 }
 
 // Payload contains the data sent in RPCs. Can contain a value and/or a list of contacts.
@@ -44,7 +46,7 @@ type Payload struct {
 // NewRPC creates a new RPC with a random ID added to it. `rpc` is the type of the RPC,
 // `senderID` is the NodeID of the node who sends it. Returns an error
 // should the RPCType be wrong.
-func NewRPC(rpc RPCType, senderID string, payload Payload) (*RPC, error) {
+func NewRPC(rpc RPCType, senderID string, targetID string, payload Payload) (*RPC, error) {
 	err := validateRPCType(rpc)
 	if err != nil {
 		return nil, err
@@ -52,7 +54,7 @@ func NewRPC(rpc RPCType, senderID string, payload Payload) (*RPC, error) {
 
 	randomStr := randarr.RandomHexString(20)
 	randomID := string(randomStr)
-	newRPC := RPC{&rpc, &payload, &randomID, &senderID}
+	newRPC := RPC{&rpc, &payload, &randomID, &senderID, &targetID}
 
 	return &newRPC, nil
 }

--- a/internal/kademlia/rpc_test.go
+++ b/internal/kademlia/rpc_test.go
@@ -8,9 +8,11 @@ import (
 
 func TestRPCUnmarshal(t *testing.T) {
 	msg := "hello"
-	contact := NewContact(NewRandomNodeID(), "10.0.8.2")
+	nodeID := NewRandomNodeID()
+	targetID := NewRandomNodeID()
+	contact := NewContact(nodeID, "10.0.8.2")
 	payload := Payload{nil, &msg, []Contact{contact}}
-	originalRPC, _ := NewRPC(Ping, "10.0.8.1", payload)
+	originalRPC, _ := NewRPC(Ping, nodeID.String(), targetID.String(), payload)
 
 	data, _ := MarshalRPC(*originalRPC)
 	marshalledRPC, _ := UnmarshalRPC(data)
@@ -29,7 +31,7 @@ func TestRPCWrongDataUnmarshal(t *testing.T) {
 func TestRPCValidateID(t *testing.T) {
 	msg := "hello"
 	payload := Payload{nil, &msg, nil}
-	originalRPC, _ := NewRPC(Store, "10.0.8.1", payload)
+	originalRPC, _ := NewRPC(Store, "", "", payload)
 	originalID := *originalRPC.ID
 
 	data, _ := MarshalRPC(*originalRPC)
@@ -56,7 +58,7 @@ func TestNewRPCCorrectTypes(t *testing.T) {
 	payload := Payload{nil, &msg, nil}
 
 	for _, rpcType := range rpcTypes {
-		_, err := NewRPC(rpcType, "10.0.8.1", payload)
+		_, err := NewRPC(rpcType, "", "", payload)
 		assert.NoError(t, err)
 	}
 }
@@ -65,6 +67,6 @@ func TestNewRPCWrongType(t *testing.T) {
 	msg := "good bye"
 	payload := Payload{nil, &msg, nil}
 
-	_, err := NewRPC("wrong type", "10.0.8.1", payload)
+	_, err := NewRPC("wrong type", "", "", payload)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
TargetID was added to RPC struct. Now when doing RPC such as FIND_NODE, it looks for the k closest contacts to the TargetID at a node. Whereas previously it looked at the k closest contacts TO the contact itself (bug).

Also update unit tests and fix a few bugs in network (found when updating unit tests)

Fixes #67 